### PR TITLE
Y24-246 - Strings are safely escaped to avoid running backtick'd commands

### DIFF
--- a/.github/workflows/generate_issue_number.yml
+++ b/.github/workflows/generate_issue_number.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Check issue title
         id: check_issue_title
         run: |
-          ISSUE_TITLE="${{ github.event.issue.title }}"
+          ISSUE_TITLE=$(printf '%q' "${{ github.event.issue.title }}")
           if [[ "$ISSUE_TITLE" =~ ^Y[0-9]{2}-[0-9]{3,4} ]]; then
             echo "VALID_TITLE=true" >> $GITHUB_OUTPUT
           else

--- a/README.md
+++ b/README.md
@@ -24,3 +24,6 @@ A GitHub appication with the correct permissions will be needed. During the acti
 3) Generate Story Number: The current issue number is incremented during the script to avoid conflicts as much as possible. The incremented number is then concatenated with the prefix to form the story number.
 4) Update Organisation Variable: The incremented issue number is saved back to the organisation variable.
 5) Modify Issue Title: The issue title is updated so that the generated story number prefixes the original story title.
+
+
+> Note: Any issues made in this repository will use the action in the `develop` branch for testing (there will no longer be extreme panic when the action fails and stops working across the organisation (hopefully))


### PR DESCRIPTION
Closes #9 

#### Changes proposed in this pull request

- Escapes the GitHub title string in the `check_issue_title` step

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
